### PR TITLE
Change rootView to android.R.id.content

### DIFF
--- a/android/app/src/main/java/com/google/transporttracker/TrackerActivity.java
+++ b/android/app/src/main/java/com/google/transporttracker/TrackerActivity.java
@@ -289,7 +289,7 @@ public class TrackerActivity extends AppCompatActivity {
         }
         Snackbar snackbar = Snackbar
                 .make(
-                        findViewById(R.id.rootView),
+                        findViewById(android.R.id.content),
                         getString(R.string.location_permission_required),
                         Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.enable, new View.OnClickListener() {
@@ -325,7 +325,7 @@ public class TrackerActivity extends AppCompatActivity {
             mSwitch.setChecked(false);
         }
         Snackbar snackbar = Snackbar
-                .make(findViewById(R.id.rootView), getString(R.string
+                .make(findViewById(android.R.id.content), getString(R.string
                         .gps_required), Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.enable, new View.OnClickListener() {
                     @Override


### PR DESCRIPTION
This is a Fix for the "Cannot find symbol variable rootView #46" Issue in the original Google Repro.